### PR TITLE
Maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "defaults/main.yml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?(?:_version|_tag)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
+    }
+  ]
+}

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,6 +8,7 @@ version = 1
 [[annotations]]
 path = [
     ".config/ansible-lint.yml",
+    ".github/renovate.json",
     "meta/main.yml",
     ".woodpecker.yml",
 ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,28 +1,34 @@
 # SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2023 - 2024 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 Sergio Durigan Junior
+# SPDX-FileCopyrightText: 2025 MASH project contributors
+# SPDX-FileCopyrightText: 2025 Suguru Hirahara
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 ---
+# Project source code URL: https://github.com/bytebeamio/rumqtt
 
 rumqttd_enabled: true
+
 rumqttd_identifier: rumqttd
+rumqttd_base_path: "/{{ rumqttd_identifier }}"
+rumqttd_config_path: "{{ rumqttd_base_path }}/config"
+
+rumqttd_version: 0.19.0
 
 rumqttd_uid: ''
 rumqttd_gid: ''
 
-rumqttd_base_path: "/{{ rumqttd_identifier }}"
-rumqttd_config_path: "{{ rumqttd_base_path }}/config"
-
 rumqttd_systemd_required_services_list: ['docker.service']
 
-rumqttd_version: 0.19.0
-
 rumqttd_container_image: "{{ rumqttd_container_image_registry_prefix }}bytebeamio/rumqttd:{{ rumqttd_container_image_tag }}"
-rumqttd_container_image_registry_prefix: docker.io/
 rumqttd_container_image_tag: "{{ rumqttd_version }}"
+rumqttd_container_image_registry_prefix: "{{ rumqttd_container_image_registry_prefix_upstream }}"
+rumqttd_container_image_registry_prefix_upstream: "{{ rumqttd_container_image_registry_prefix_upstream_default }}"
+rumqttd_container_image_registry_prefix_upstream_default: docker.io/
 rumqttd_container_image_force_pull: "{{ rumqttd_container_image.endswith(':latest') }}"
-
-rumqttd_container_network: '{{ rumqttd_identifier }}'
 
 # The port number in the container
 rumqttd_container_http_port: 1883
@@ -32,7 +38,12 @@ rumqttd_container_http_port: 1883
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8731"), or empty string to not expose.
 rumqttd_container_http_host_bind_port: "1883"
 
+# The base container network. It will be auto-created by this role if it doesn't exist already.
+rumqttd_container_network: '{{ rumqttd_identifier }}'
+
 # A list of additional container networks that the container would be connected to.
 # The role does not create these networks, so make sure they already exist.
-# Use this to expose this container to a reverse proxy, which runs in a different container network.
-rumqttd_container_additional_networks: []
+# Use this to expose this container to another reverse proxy, which runs in a different container network.
+rumqttd_container_additional_networks: "{{ rumqttd_container_additional_networks_auto + rumqttd_container_additional_networks_custom }}"
+rumqttd_container_additional_networks_auto: []
+rumqttd_container_additional_networks_custom: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ rumqttd_identifier: rumqttd
 rumqttd_base_path: "/{{ rumqttd_identifier }}"
 rumqttd_config_path: "{{ rumqttd_base_path }}/config"
 
+# renovate: datasource=docker depName=bytebeamio/rumqttd versioning=semver
 rumqttd_version: 0.19.0
 
 rumqttd_uid: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ rumqttd_container_http_port: 1883
 # Controls whether the rumqttd container exposes its HTTP port (as defined by `rumqttd_container_http_port`).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8731"), or empty string to not expose.
-rumqttd_container_http_host_bind_port: "1883"
+rumqttd_container_http_host_bind_port: "{{ rumqttd_container_http_port }}"
 
 # The base container network. It will be auto-created by this role if it doesn't exist already.
 rumqttd_container_network: '{{ rumqttd_identifier }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ rumqttd_config_path: "{{ rumqttd_base_path }}/config"
 
 rumqttd_systemd_required_services_list: ['docker.service']
 
-rumqttd_version: 0.21.0
+rumqttd_version: 0.19.0
 
 rumqttd_container_image: "{{ rumqttd_container_image_registry_prefix }}bytebeamio/rumqttd:{{ rumqttd_container_image_tag }}"
 rumqttd_container_image_registry_prefix: docker.io/

--- a/docs/configuring-rumqttd.md
+++ b/docs/configuring-rumqttd.md
@@ -45,6 +45,14 @@ rumqttd_enabled: true
 ########################################################################
 ```
 
+### Change the MQTT port (optional)
+
+If you need to change the MQTT port, add the following configuration to your `vars.yml` file (adapt to your needs).
+
+```yaml
+rumqttd_container_http_host_bind_port: "1884"
+```
+
 ## Installing
 
 After configuring the playbook, run the installation command of your playbook as below:


### PR DESCRIPTION
This was tested while I was checking the role's implementation for Mosquitto along with it at https://github.com/mother-of-all-self-hosting/ansible-role-mosquitto/pull/1.

I am not sure the details (maybe deleted?), but `0.21.0` is not available; `0.19.0` is the latest version.

`rumqttd_container_http_host_bind_port` was modifed as well.